### PR TITLE
optimize use of default data for template

### DIFF
--- a/opt/dect-wip/app.py
+++ b/opt/dect-wip/app.py
@@ -22,6 +22,8 @@ config.read('config.ini')
 pjsip_wizard_user_conf = config['asterisk'].get('pjsip_wizard_user_conf')
 pjsip_wizard_temp_conf = config['asterisk'].get('pjsip_wizard_temp_conf')
 
+event_name = config['event'].get('name')
+
 database_name = 'database.sqlite3'
 
 app = Flask(__name__)
@@ -258,10 +260,14 @@ def trigger():
 
 
 def fetch_default_data_for_templates():
-    data = {'displayname': ''}
+    data = {
+        'current_user': current_user,
+        'event_name': event_name
+        }
+    print(data)
 
-    if current_user.is_authenticated:
-        data['displayname'] = current_user.displayname
+    #if current_user.is_authenticated:
+    #    data['displayname'] = current_user.displayname
 
     return data
 

--- a/opt/dect-wip/config.ini.sample
+++ b/opt/dect-wip/config.ini.sample
@@ -1,6 +1,9 @@
 [flask]
 secret_key = '7355608'
 
+[event]
+name = annual ADE meeting
+
 [omm]
 ip = 10.10.10.10
 port = 12621

--- a/opt/dect-wip/templates/base.html.j2
+++ b/opt/dect-wip/templates/base.html.j2
@@ -11,14 +11,14 @@
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.2/font/bootstrap-icons.css">
 
-    <title>ADE-USS-DECT</title>
+    <title>EDA DECT</title>
 </head>
 
 <body>
 
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container-fluid">
-            <a class="navbar-brand" href="#"><i class="bi bi-reception-4 me-1"></i>ADE-USS-DECT</a>
+            <a class="navbar-brand" href="#"><i class="bi bi-reception-4 me-1"></i>EDA @ {{ default_data.event_name }}</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -28,12 +28,11 @@
                     <li class="nav-item">
                         <a class="nav-link active" href="/phonebook">Telefonbuch</a>
                     </li>
+                    <!-- Login/Logout -->
+                    {% if default_data.current_user.is_authenticated %}
                     <li class="nav-item">
                         <a class="nav-link" href="/myextensions">Meine Rufnummern</a>
                     </li>
-
-                    <!-- Login/Logout -->
-                    {% if default_data.displayname|length > 0 %}
                     <li class="nav-item">
                         <a class="nav-link" href="/logout/">Logout</a>
                     </li>

--- a/opt/dect-wip/templates/phonebook.html.j2
+++ b/opt/dect-wip/templates/phonebook.html.j2
@@ -5,7 +5,7 @@
 <!-- Überschrift -->
 
     <div class="container-xl mt-3 mb-3">
-        <p class="h3">offizielles™ ADE-USS-DECT-Telefonbuch:</p>
+        <p class="h3">offizielles™ {{ default_data.event_name }}-Telefonbuch:</p>
     </div>
 
     <!-- Suchfeld -->


### PR DESCRIPTION
in default data for templates, hand over complete current_user object instead of displayname only, so we can use flask-login's .is_authenticated

edit base template accordingly and use the .is_authenticated instead of displayname > 0

bugfix: when not logged in, do not show "my extensions" in the title bar.

added event/name to config.ini
added eventname to default data for templates
edited project name in title bar to EDA @ {{eventname}}