### PR TITLE
fix: not closing tr blocks in the phonebook

### DIFF
--- a/services/dect-wip/templates/phonebook.html.j2
+++ b/services/dect-wip/templates/phonebook.html.j2
@@ -36,7 +36,7 @@
                     <td>{{ext.extension}}</td>
                     <td>{{ext.name}}</td>
                     <td>{{ext.info}}</td>
-                <tr>
+                </tr>
             {% endfor %}
 
             </tbody>


### PR DESCRIPTION
Fixes #55 

this adds additional tr blocks in firefox/librewolf that have no td elements which breaks the search function, because that one tries to access the td elements with fixed indices.