### PR TITLE
feat: Add WGSI interfaces to dect-wip and dect-wip-ommsync, Add Env var support for most important settings

### DIFF
--- a/services/dect-wip-mitel-phonebook/phonebook.py
+++ b/services/dect-wip-mitel-phonebook/phonebook.py
@@ -1,7 +1,8 @@
 from bottle import route, run, request, template
 import requests
+import os
 
-dect_wip_ip = "127.0.0.1:8080"
+dect_wip_ip = os.getenv('DECT_WIP_URL', '127.0.0.1:8080')
 
 xsi_template = """<?xml version="1.0" encoding="UTF-8"?>
 <Personal xmlns="http://schema.broadsoft.com/xsi”>
@@ -34,4 +35,5 @@ def return_phonebook(caller):
 
     return template(xsi_template, names_and_extensions=names_and_extensions)
 
-run(host='0.0.0.0', port=8082, debug=False)
+port = os.getenv('DECT_WIP_PHONEBOOK_PORT', '8082')
+run(host='0.0.0.0', port=port, debug=False)

--- a/services/dect-wip-ommsync/dect-wip-ommsync.py
+++ b/services/dect-wip-ommsync/dect-wip-ommsync.py
@@ -96,7 +96,16 @@ def init(config_path):
     omm_username = config['omm'].get('username')
     omm_password = config['omm'].get('password')
 
-    client = mitel_ommclient2.OMMClient2(host=omm_ip, port=omm_port, username=omm_username, password=omm_password, ommsync=True)
+    try:
+        client = mitel_ommclient2.OMMClient2(
+            host=omm_ip,
+            port=omm_port,
+            username=omm_username,
+            password=omm_password,
+            ommsync=True
+        )
+    except (TimeoutError) as e:
+        raise RuntimeError("Connection to OMM timed out") from e
 
     dect_wip_ip = os.getenv('DECT_WIP_IP', '127.0.0.1:8080')
 

--- a/services/dect-wip-ommsync/dect-wip-ommsync.py
+++ b/services/dect-wip-ommsync/dect-wip-ommsync.py
@@ -5,22 +5,12 @@ import requests
 import namegenerator
 import utilities
 from threading import Lock
-
-dect_wip_ip = "127.0.0.1:8080"
+import click
+import os
 
 print('Make sure Subscription and Auto-Create are enabled')
 
-config = configparser.ConfigParser()
-config.read('/etc/dect-wip.ini')
-
-omm_ip = config['omm'].get('ip')
-omm_port = config['omm'].getint('port')
-omm_username = config['omm'].get('username')
-omm_password = config['omm'].get('password')
-
 lock = Lock()
-client = mitel_ommclient2.OMMClient2(host=omm_ip, port=omm_port, username=omm_username, password=omm_password, ommsync=True)
-
 app = Flask(__name__)
 
 @app.route('/connect/', methods=['POST'])
@@ -90,9 +80,38 @@ def makeTemps():
             print(response.text)
     return "success", 200
 
+def init(config_path):
 
-if __name__ == "__main__":
-    #app.secret_key = config['flask'].get('secret_key')
+    # setup global config
 
+    global config, dect_wip_ip, omm_ip, omm_port, omm_username, omm_password, client 
+
+    print(f'Using config: {config_path}')
+
+    config = configparser.ConfigParser()
+    config.read(config_path)
+
+    omm_ip = config['omm'].get('ip')
+    omm_port = config['omm'].getint('port')
+    omm_username = config['omm'].get('username')
+    omm_password = config['omm'].get('password')
+
+    client = mitel_ommclient2.OMMClient2(host=omm_ip, port=omm_port, username=omm_username, password=omm_password, ommsync=True)
+
+    dect_wip_ip = os.getenv('DECT_WIP_IP', '127.0.0.1:8080')
+
+
+@click.command()
+@click.option('--config', 'config_path', envvar='CONFIG', default='/etc/dect-wip.ini', help='optional config location')
+def init_dev(config_path):
+    init(config_path)
     # run webserver/app
     app.run(host='0.0.0.0', port=8081, debug=False, use_reloader=True)
+
+def init_wsgi():
+    config_path = os.getenv('CONFIG', '/etc/dect-wip.ini')
+    init(config_path)
+    return app
+
+if __name__ == "__main__":
+    init_dev()

--- a/services/dect-wip-ommsync/dect-wip-ommsync.py
+++ b/services/dect-wip-ommsync/dect-wip-ommsync.py
@@ -94,7 +94,10 @@ def init(config_path):
     omm_ip = config['omm'].get('ip')
     omm_port = config['omm'].getint('port')
     omm_username = config['omm'].get('username')
-    omm_password = config['omm'].get('password')
+    omm_password = (
+    open(os.getenv('OMM_PW_PATH')).read().strip() 
+    if os.getenv('OMM_PW_PATH') else config['omm'].get('password')
+    )
 
     try:
         client = mitel_ommclient2.OMMClient2(

--- a/services/dect-wip/app.py
+++ b/services/dect-wip/app.py
@@ -17,8 +17,11 @@ from database import UserExtension,TempExtension,User # database models
 scheduler = APScheduler()
 login_manager = LoginManager()
 
-
-app = Flask(__name__)
+instance_path = os.getenv('INSTANCE_PATH')
+if(instance_path):
+    app = Flask(__name__, instance_path="/tmp/")
+else:
+    app = Flask(__name__)
 
 # config
 
@@ -459,9 +462,6 @@ def fetch_default_data_for_templates():
 
     return data
 
-
-@click.command()
-@click.option('--config', 'config_path', envvar='CONFIG', default='/etc/dect-wip.ini', help='optional config location')
 def init(config_path):
 
     # setup global config
@@ -528,9 +528,17 @@ def init(config_path):
         print('enabling Swagger - /apidocs/')
         swagger = Swagger(app)
 
+@click.command()
+@click.option('--config', 'config_path', envvar='CONFIG', default='/etc/dect-wip.ini', help='optional config location')
+def init_dev(config_path):
+    init(config_path)
     # run webserver/app
     app.run(host='0.0.0.0', port=8080, debug=False, use_reloader=True)
 
+def init_wsgi():
+    config_path = os.getenv('CONFIG', '/etc/dect-wip.ini')
+    init(config_path)
+    return app
 
 if __name__ == "__main__":
-    init()
+    init_dev()

--- a/services/dect-wip/app.py
+++ b/services/dect-wip/app.py
@@ -444,7 +444,7 @@ def trigger():
         client.logoff()
 
 def triggerOmm():
-    response = requests.get(f"http://{ommsync_url}/trigger")
+    response = requests.get(f"{ommsync_url}/trigger")
     return #TODO: remove
 
 
@@ -506,7 +506,7 @@ def init(config_path):
     if os.getenv('FLASK_SECRET_KEY_PATH') else config['flask'].get('secret_key')
     )
 
-    ommsync_url = os.getenv('OMMSYNC_URL', '127.0.0.1:8081')
+    ommsync_url = os.getenv('OMMSYNC_URL', 'http://127.0.0.1:8081')
 
     # autogenerate secret_key if not provided
     if not app.secret_key:

--- a/services/dect-wip/app.py
+++ b/services/dect-wip/app.py
@@ -444,7 +444,7 @@ def trigger():
         client.logoff()
 
 def triggerOmm():
-    response = requests.get("http://127.0.0.1:8081/trigger")
+    response = requests.get(f"http://{ommsync_url}/trigger")
     return #TODO: remove
 
 
@@ -466,7 +466,7 @@ def init(config_path):
 
     # setup global config
 
-    global pjsip_wizard_user_conf, pjsip_wizard_temp_conf, event_name, token_prefix, token_random_count, show_voucher, dectwip_config
+    global pjsip_wizard_user_conf, pjsip_wizard_temp_conf, event_name, token_prefix, token_random_count, show_voucher, dectwip_config, ommsync_url
 
     print(f'Using config: {config_path}')
 
@@ -475,13 +475,16 @@ def init(config_path):
 
     pjsip_wizard_user_conf = config['asterisk'].get('pjsip_wizard_user_conf')
     pjsip_wizard_temp_conf = config['asterisk'].get('pjsip_wizard_temp_conf')
+    ami_pw = (
+    open(os.getenv('AMI_PW_PATH')).read().strip() if os.getenv('AMI_PW_PATH') else config['asterisk'].get('ami_password')
+    )
     dectwip_config = {
         'asterisk': {
             'ami': {
                 'host': config['asterisk'].get('ami_host'),
                 'port': int(config['asterisk'].get('ami_port')),
                 'user': config['asterisk'].get('ami_user'),
-                'password': config['asterisk'].get('ami_password')
+                'password': ami_pw
                 
             }
         },
@@ -498,7 +501,12 @@ def init(config_path):
     show_voucher = config['event'].get('show_voucher', 'True')
 
     # init flask
-    app.secret_key = config['flask'].get('secret_key')
+    app.secret_key = (
+    open(os.getenv('FLASK_SECRET_KEY_PATH')).read().strip() 
+    if os.getenv('FLASK_SECRET_KEY_PATH') else config['flask'].get('secret_key')
+    )
+
+    ommsync_url = os.getenv('OMMSYNC_URL', '127.0.0.1:8081')
 
     # autogenerate secret_key if not provided
     if not app.secret_key:


### PR DESCRIPTION
Hey there,

I wrote a NixOS wrapper for dect-wip.
For that, I needed to use WSGI, so I added interfaces to run Gunicorn as a production-ready WSGI server.

I also added environment variable options, allowing me to configure the basic parameters of each application through NixOS or a systemd service.
To handle passwords more easily, I added an option to supply an environment variable pointing to a password file, whose content is then parsed as the password.

All my changes are designed with the current architecture in mind, so they only add new flexibility to the application. If you use the architecture recommended by this repository, there should be no changes or manual tasks required.

Thank you all for this amazing project!