### PR TITLE
chore: phonebook not always active in menu

### DIFF
--- a/services/dect-wip/templates/base.html.j2
+++ b/services/dect-wip/templates/base.html.j2
@@ -25,7 +25,7 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link active" href="/phonebook">Telefonbuch</a>
+                        <a class="nav-link" href="/phonebook">Telefonbuch</a>
                     </li>
                     <!-- Login/Logout -->
                     {% if default_data.current_user.is_authenticated %}


### PR DESCRIPTION
The Phonebook Link in the menu is always bold and active/marked.
Removed CSS class.