### PR TITLE
feat/fix: rewrite mitel-phonebook microservice in flask

### DIFF
--- a/services/dect-wip-mitel-phonebook/phonebook.py
+++ b/services/dect-wip-mitel-phonebook/phonebook.py
@@ -27,7 +27,7 @@ def return_phonebook(caller):
     search_index = int(search_index)-1 # let search_index start at 0 not 1
     search_results_count = int(request.args.get('results'))
 
-    if config.getboolean('phonebook','always_search_with_contains'):
+    if always_search_with_contains:
         if not search_string.startswith('*'):
             print(f'config.ini phonebook always_search_with_contains is true --> converting {search_string} to *{search_string}')
             search_string = f'*{search_string}'
@@ -51,12 +51,26 @@ def return_phonebook(caller):
 
     return render_template_string(xsi_template, names_and_extensions=names_and_extensions)
 
+def init(config_path):
+
+    # setup global config
+
+    global always_search_with_contains
+
+    config.read(config_path)
+    always_search_with_contains = config.getboolean('phonebook', 'always_search_with_contains')
+
 @click.command()
 @click.option('--config', 'config_path', envvar='CONFIG', default='/etc/dect-wip.ini', help='optional config location')
-def init(config_path):
+def init_dev(config_path):
     # TODO: refactor config.ini and ENV
-    config.read(config_path)
+    init(config_path)
     app.run(host='0.0.0.0', port=port, debug=False, use_reloader=True)
+
+def init_wsgi():
+    config_path = os.getenv('CONFIG', '/etc/dect-wip.ini')
+    init(config_path)
+    return app
 
 if __name__ == '__main__':
     init()

--- a/services/dect-wip-mitel-phonebook/phonebook.py
+++ b/services/dect-wip-mitel-phonebook/phonebook.py
@@ -1,39 +1,62 @@
-from bottle import route, run, request, template
+from flask import Flask, request, render_template_string
 import requests
 import os
+import configparser
+import click
 
 dect_wip_ip = os.getenv('DECT_WIP_URL', '127.0.0.1:8080')
+port = int(os.getenv('DECT_WIP_PHONEBOOK_PORT', '8082'))
+app = Flask(__name__)
+config = configparser.ConfigParser()
 
-xsi_template = """<?xml version="1.0" encoding="UTF-8"?>
+xsi_template = """"<?xml version="1.0" encoding="UTF-8"?>
 <Personal xmlns="http://schema.broadsoft.com/xsi”>
-% for entry in names_and_extensions:
+{% for entry in names_and_extensions: %}
 <entry>
 <name>{{entry["name"]}}</name>
 <number>{{entry["extension"]}}</number>
 </entry>
-% end
+{% endfor %}
 </Personal>"""
 
-
-@route('/com.broadsoft.xsi-actions/v2.0/user/<caller>/directories/personal')
+@app.route('/com.broadsoft.xsi-actions/v2.0/user/<caller>/directories/personal')
 def return_phonebook(caller):
 
-    search_string = request.query.name
-    search_index = request.query.start
-    search_results = request.query.results
+    search_string = request.args.get('name')
+    search_index = request.args.get('start')
+    search_index = int(search_index)-1 # let search_index start at 0 not 1
+    search_results_count = int(request.args.get('results'))
 
-    search_string = search_string.replace('*','')
+    if config.getboolean('phonebook','always_search_with_contains'):
+        if not search_string.startswith('*'):
+            print(f'config.ini phonebook always_search_with_contains is true --> converting {search_string} to *{search_string}')
+            search_string = f'*{search_string}'
+        if not search_string.endswith('*'):
+            print(f'config.ini phonebook always_search_with_contains is true --> converting {search_string} to {search_string}*')
+            search_string = f'{search_string}*'
 
-    print(search_string)
+    search_string = search_string.replace('*','%')
 
     if search_string == '':
         names_and_extensions = requests.get(f"http://{dect_wip_ip}/api/v1/phonebook").json()
     else:
         names_and_extensions = requests.get(f"http://{dect_wip_ip}/api/v1/phonebook?search={search_string}").json() 
 
-    print(f"{caller} hat nach {search_string} gesucht, i={search_index}, n={search_results}")
+    print(f"{caller} searched for {search_string}, index={search_index}, results_count={search_results_count}")
 
-    return template(xsi_template, names_and_extensions=names_and_extensions)
+    # limit amount to requests search_index and search_string
+    names_and_extensions = names_and_extensions[
+        search_index : search_index+search_results_count
+    ]
 
-port = os.getenv('DECT_WIP_PHONEBOOK_PORT', '8082')
-run(host='0.0.0.0', port=port, debug=False)
+    return render_template_string(xsi_template, names_and_extensions=names_and_extensions)
+
+@click.command()
+@click.option('--config', 'config_path', envvar='CONFIG', default='/etc/dect-wip.ini', help='optional config location')
+def init(config_path):
+    # TODO: refactor config.ini and ENV
+    config.read(config_path)
+    app.run(host='0.0.0.0', port=port, debug=False, use_reloader=True)
+
+if __name__ == '__main__':
+    init()

--- a/services/dect-wip-mitel-phonebook/phonebook.py
+++ b/services/dect-wip-mitel-phonebook/phonebook.py
@@ -9,8 +9,8 @@ port = int(os.getenv('DECT_WIP_PHONEBOOK_PORT', '8082'))
 app = Flask(__name__)
 config = configparser.ConfigParser()
 
-xsi_template = """"<?xml version="1.0" encoding="UTF-8"?>
-<Personal xmlns="http://schema.broadsoft.com/xsi”>
+xsi_template = """<?xml version="1.0" encoding="UTF-8"?>
+<Personal xmlns="http://schema.broadsoft.com/xsi">
 {% for entry in names_and_extensions: %}
 <entry>
 <name>{{entry["name"]}}</name>

--- a/services/dect-wip-mitel-phonebook/requirements.txt
+++ b/services/dect-wip-mitel-phonebook/requirements.txt
@@ -1,2 +1,2 @@
-bottle==0.12.25
+flask
 requests

--- a/services/dect-wip/app.py
+++ b/services/dect-wip/app.py
@@ -40,9 +40,19 @@ def load_user(user_id):
 
 
 def getUserExtensions(filterByUserId: User.id | None, searchFor: str | None, showPublicOnly: bool = True) -> list:
+    """
+    Retrieve user extensions from the database sorted by name
 
+    Args:
+        filterByUserId: Restrict results to extensions owned by the given user ID
+        searchFor: SQL LIKE pattern used to filter extension names
+        showPublicOnly: only public extensions are returned
+
+    Returns:
+        list: list of user extensions sorted by name
+    """
     query = db.select(UserExtension).order_by(UserExtension.name.asc())
-    
+
     if showPublicOnly:
         query = query.filter_by(public=True)                     
 
@@ -50,7 +60,7 @@ def getUserExtensions(filterByUserId: User.id | None, searchFor: str | None, sho
         query = query.filter_by(user_id=filterByUserId)
 
     if searchFor is not None:
-        query = query.filter(UserExtension.name.icontains(searchFor))
+        query = query.filter(UserExtension.name.like(searchFor))
 
     return db.session.execute(query).scalars().all()
 
@@ -359,7 +369,7 @@ def phonebook_json():
     """
 
 
-    search_string = request.args.get('search')
+    search_string = f"%{request.args.get('search')}%"
     
     query_result = getUserExtensions(filterByUserId=None,searchFor=search_string,showPublicOnly=True)
 

--- a/systemfiles/etc/dect-wip.ini.sample
+++ b/systemfiles/etc/dect-wip.ini.sample
@@ -25,3 +25,8 @@ ami_host = 127.0.0.1
 ami_port = 5038
 ami_user = dect-wip
 ami_password = changeME
+
+[phonebook]
+# Mitel XSI-Personal-Directory usually searches for foobar*
+# if this option is set to true we add * at the beginning and do basically a contains(*foobar*) search not a starts with(foobar*)
+always_search_with_contains = True


### PR DESCRIPTION
rewrite phonebook in flask after bootle.py implementation broke.
Improved the search to respect starts_with.
But added the option to convert starts_with from omm-phonebook to contains as default true.

OMM did searched for foobar*
We always returned the results for \*foobar*

This is still the default but can be turned off in the .ini now.
