### PR TITLE
improve scheduler for asterisk and omm sync and move extension management to API

### DIFF
--- a/API-Endpoints.md
+++ b/API-Endpoints.md
@@ -81,7 +81,3 @@ Listen-Port: 8081
 Connect the User to his real Extenstion.
 Change TMP-Credentials to User-Credentials in OMM.
 Uses Token to find User-Extenstion.
-
-`/trigger/`
-
-Create TMP-Extenstions for all Unbound Dect-Handsets in OMM

--- a/API-Endpoints.md
+++ b/API-Endpoints.md
@@ -31,9 +31,19 @@ returns HTML-Phonebook for User
 
 `/myextensions/`
 
-[POST] - add extenstion
-[DELETE] - delete extenstion
 [GET] - show WebUI
+
+`/api/v1/GetUserExtensions`
+
+[GET] - get users extensions
+
+`/api/v1/CreateUserExtension`
+
+[POST] - add extenstion
+
+`/api/v1/DeleteUserExtension`
+
+[POST] - delete extenstion
 
 `/api/v1/GetUserExtensionByToken/<token>`
 

--- a/services/dect-wip-ommsync/dect-wip-ommsync.py
+++ b/services/dect-wip-ommsync/dect-wip-ommsync.py
@@ -1,17 +1,20 @@
 import configparser
 import mitel_ommclient2
 from flask import Flask, request, jsonify, make_response
+from flask_apscheduler import APScheduler
 import requests
 import namegenerator
 import utilities
 from threading import Lock
 import click
 import os
+from datetime import datetime
 
 print('Make sure Subscription and Auto-Create are enabled')
 
 lock = Lock()
 app = Flask(__name__)
+scheduler = APScheduler()
 
 @app.route('/connect/', methods=['POST'])
 def connect():
@@ -49,8 +52,7 @@ def connect():
         response = make_response(jsonify( {"message": "extension added"}), 200)
     return response
 
-
-@app.route('/trigger/', methods=['GET'])
+@scheduler.task('interval', id='makeTemps', seconds=5, next_run_time=datetime.now(), max_instances=1)
 def makeTemps():
     print("lets go")
 
@@ -73,12 +75,11 @@ def makeTemps():
                 "uid": newuser.uid,
                 "ppn": device.ppn
             }
-    
+
             print(data)
     
             response = requests.post(f"http://{dect_wip_ip}/api/v1/AddTempExtensionToDB", json=data)
             print(response.text)
-    return "success", 200
 
 def init(config_path):
 
@@ -111,6 +112,9 @@ def init(config_path):
         raise RuntimeError("Connection to OMM timed out") from e
 
     dect_wip_ip = os.getenv('DECT_WIP_IP', '127.0.0.1:8080')
+
+    scheduler.init_app(app)
+    scheduler.start()
 
 
 @click.command()

--- a/services/dect-wip/app.py
+++ b/services/dect-wip/app.py
@@ -451,11 +451,6 @@ def trigger():
         finally:
             client.logoff()
 
-def triggerOmm():
-    response = requests.get(f"{ommsync_url}/trigger")
-    return #TODO: remove
-
-
 
 def fetch_default_data_for_templates():
     data = {
@@ -474,7 +469,7 @@ def init(config_path):
 
     # setup global config
 
-    global pjsip_wizard_user_conf, pjsip_wizard_temp_conf, event_name, token_prefix, token_random_count, show_voucher, dectwip_config, ommsync_url
+    global pjsip_wizard_user_conf, pjsip_wizard_temp_conf, event_name, token_prefix, token_random_count, show_voucher, dectwip_config
 
     print(f'Using config: {config_path}')
 
@@ -514,8 +509,6 @@ def init(config_path):
     if os.getenv('FLASK_SECRET_KEY_PATH') else config['flask'].get('secret_key')
     )
 
-    ommsync_url = os.getenv('OMMSYNC_URL', 'http://127.0.0.1:8081')
-
     # autogenerate secret_key if not provided
     if not app.secret_key:
         app.secret_key = utilities.getRandomStr(16)
@@ -534,7 +527,6 @@ def init(config_path):
 
     scheduler.init_app(app)
     scheduler.add_job(id='trigger', func=trigger, trigger='interval', seconds=5)
-    scheduler.add_job(id='triggerOmm', func=triggerOmm, trigger='interval', seconds=5)
     scheduler.start()
 
     app.add_template_filter(utilities.format_token, 'format_token')

--- a/services/dect-wip/app.py
+++ b/services/dect-wip/app.py
@@ -234,7 +234,7 @@ def CreateUserExtension():
 
             response = make_response(jsonify( {"message": "extension added"}), 200)
 
-            poke_asterisk_soon()
+            schedule_asterisk_configuration_update()
         except:
             response = make_response(jsonify( {"message": "extension can't be added. Do you need a voucher?"}), 400)
 
@@ -277,7 +277,7 @@ def DeleteUserExtension():
 
         response = make_response(jsonify( {"message": "extension deleted"}), 200)
 
-        poke_asterisk_soon()
+        schedule_asterisk_configuration_update()
     else:
         response = make_response(jsonify( {"message": "extension not owned by user"}), 403)
     return response
@@ -425,7 +425,7 @@ def AddTempExtensionToDB():
     db.session.add(ext)
     db.session.commit()
 
-    poke_asterisk_soon()
+    schedule_asterisk_configuration_update()
     
     return "success", 200
 
@@ -504,7 +504,7 @@ def ClaimExtensionByVoucher():
     )
     db.session.commit()
 
-    poke_asterisk_soon()
+    schedule_asterisk_configuration_update()
 
     #TODO: add number of extensions added
     
@@ -527,8 +527,8 @@ def writePjsip():
     utilities.pjsipConfig(pjsip_wizard_temp_conf, tempExts, "temp_dect")
 
 # Generates new Asterisk configs and pokes Asterisk to reload configs
-@scheduler.task('interval', id='poke_asterisk', seconds=300, next_run_time=datetime.now(), max_instances=1)  # every 5min, is called immediately on changes in the db
-def poke_asterisk():
+@scheduler.task('interval', id='update_asterisk_configuration', seconds=300, next_run_time=datetime.now(), max_instances=1)  # every 5min, is called immediately on changes in the db
+def update_asterisk_configuration():
     with lock_asterisk:
         with app.app_context():
             writePjsip()
@@ -557,8 +557,8 @@ def poke_asterisk():
                 client.logoff()
 
 # schedules a task to poke asterisk soon^TM
-def poke_asterisk_soon():  # TM
-    scheduler.modify_job('poke_asterisk', next_run_time=datetime.now())
+def schedule_asterisk_configuration_update():
+    scheduler.modify_job('update_asterisk_configuration', next_run_time=datetime.now())
 
 
 def fetch_default_data_for_templates():

--- a/services/dect-wip/app.py
+++ b/services/dect-wip/app.py
@@ -11,6 +11,8 @@ from flask_login import LoginManager, login_user, login_required, logout_user, c
 import click
 import requests
 from flasgger import Swagger
+from threading import Lock
+from datetime import datetime
 
 from database import db # database object
 from database import UserExtension,TempExtension,User # database models
@@ -194,6 +196,8 @@ def myextensions():
                 db.session.commit()
 
                 response = make_response(jsonify( {"message": "extension added"}), 200)
+
+                poke_asterisk_soon()
             except:
                 response = make_response(jsonify( {"message": "extension can't be added. Do you need a voucher?"}), 400)
 
@@ -215,6 +219,8 @@ def myextensions():
             db.session.commit()
 
             response = make_response(jsonify( {"message": "extension deleted"}), 200)
+
+            poke_asterisk_soon()
         else:
             response = make_response(jsonify( {"message": "extension not owned by user"}), 403)
         return response
@@ -331,6 +337,8 @@ def AddTempExtensionToDB():
     
     db.session.add(ext)
     db.session.commit()
+
+    poke_asterisk_soon()
     
     return "success", 200
 
@@ -409,12 +417,19 @@ def ClaimExtensionByVoucher():
     )
     db.session.commit()
 
+    poke_asterisk_soon()
+
     #TODO: add number of extensions added
     
     return "success", 200
 
 
+lock_asterisk = Lock()
+
+# generates Asterisk config
 def writePjsip():
+    if lock_asterisk.locked():
+        raise RuntimeError("the writePjsip function assumes that the asterisk lock is already acquired by the calling function")
 
     query_result = db.session.execute(db.select(UserExtension)).all()
     userExts = [ x[0] for x in query_result ] 
@@ -424,32 +439,39 @@ def writePjsip():
     tempExts = [ x[0] for x in query_result ] 
     utilities.pjsipConfig(pjsip_wizard_temp_conf, tempExts, "temp_dect")
 
-def trigger():
-    with app.app_context():
-        writePjsip()
+# Generates new Asterisk configs and pokes Asterisk to reload configs
+@scheduler.task('interval', id='poke_asterisk', seconds=300, next_run_time=datetime.now(), max_instances=1)  # every 5min, is called immediately on changes in the db
+def poke_asterisk():
+    with lock_asterisk:
+        with app.app_context():
+            writePjsip()
 
-        from asterisk.ami import AMIClient, SimpleAction
-        client = AMIClient(
-            address=dectwip_config['asterisk']['ami']['host'],
-            port=dectwip_config['asterisk']['ami']['port']
-        )
-        client.login(
-            username=dectwip_config['asterisk']['ami']['user'],
-            secret=dectwip_config['asterisk']['ami']['password']
-        )
-        try:
-            action = SimpleAction('Command', Command='module reload res_pjsip_config_wizard.so')
-            result = client.send_action(action)
-            response = result.response if hasattr(result, 'response') else result
+            from asterisk.ami import AMIClient, SimpleAction
+            client = AMIClient(
+                address=dectwip_config['asterisk']['ami']['host'],
+                port=dectwip_config['asterisk']['ami']['port']
+            )
+            client.login(
+                username=dectwip_config['asterisk']['ami']['user'],
+                secret=dectwip_config['asterisk']['ami']['password']
+            )
+            try:
+                action = SimpleAction('Command', Command='module reload res_pjsip_config_wizard.so')
+                result = client.send_action(action)
+                response = result.response if hasattr(result, 'response') else result
 
-            status = getattr(response, 'status', '').lower()
-            output = response.keys.get('Output', '') if isinstance(getattr(response, 'keys', None), dict) else ''
+                status = getattr(response, 'status', '').lower()
+                output = response.keys.get('Output', '') if isinstance(getattr(response, 'keys', None), dict) else ''
 
-            if not (status == 'success' and 'reloaded successfully' in output.lower()):
-                print(f"PJSIP reload failed — status: {status}, output: {output}")
-                raise RuntimeError(f"PJSIP reload failed: {output or status}")
-        finally:
-            client.logoff()
+                if not (status == 'success' and 'reloaded successfully' in output.lower()):
+                    print(f"PJSIP reload failed — status: {status}, output: {output}")
+                    raise RuntimeError(f"PJSIP reload failed: {output or status}")
+            finally:
+                client.logoff()
+
+# schedules a task to poke asterisk soon^TM
+def poke_asterisk_soon():  # TM
+    scheduler.modify_job('poke_asterisk', next_run_time=datetime.now())
 
 
 def fetch_default_data_for_templates():
@@ -526,7 +548,6 @@ def init(config_path):
     login_manager.init_app(app)
 
     scheduler.init_app(app)
-    scheduler.add_job(id='trigger', func=trigger, trigger='interval', seconds=5)
     scheduler.start()
 
     app.add_template_filter(utilities.format_token, 'format_token')

--- a/services/dect-wip/app.py
+++ b/services/dect-wip/app.py
@@ -174,64 +174,151 @@ def phonebook():
     return render_template('phonebook.html.j2', default_data=fetch_default_data_for_templates(), exts=exts)
 
 
-@app.route('/myextensions/', methods=['POST', 'DELETE', 'GET'])
+@app.route('/myextensions/', methods=['GET'])
 @login_required
 def myextensions():
+    exts = getUserExtensions(filterByUserId=current_user.id, searchFor=None, showPublicOnly=False)
 
-    if request.method == 'POST':
-        req_json = request.get_json()
-        ext = UserExtension()
-
-        ext.extension = html.escape(req_json['extension'])
-        ext.password = utilities.getRandomNumber(20)
-        ext.name = html.escape(req_json['name'])
-        ext.info = html.escape(req_json['info'])
-        ext.public = bool(req_json['public'])
-        ext.token = f'{token_prefix}{utilities.getRandomNumber(token_random_count)}'
-        ext.user_id = current_user.id
-
-        if len(ext.extension) == 4 and ext.extension.isdigit() and int(ext.extension[:1]) > 0:
-            try:
-                db.session.add(ext)
-                db.session.commit()
-
-                response = make_response(jsonify( {"message": "extension added"}), 200)
-
-                poke_asterisk_soon()
-            except:
-                response = make_response(jsonify( {"message": "extension can't be added. Do you need a voucher?"}), 400)
-
-
-        else:
-            response = make_response(jsonify( {"message": "you need 4 digits"}), 400)
-        return response
-
-    if request.method == 'DELETE':
-
-        req_json = request.get_json()
-        selection = db.select(UserExtension).filter_by(extension = req_json['extension'])
-        ext = db.session.execute(selection).first()
-
-        ext = ext[0]
-
-        if ext.user_id == current_user.id:
-            db.session.delete(ext)
-            db.session.commit()
-
-            response = make_response(jsonify( {"message": "extension deleted"}), 200)
-
-            poke_asterisk_soon()
-        else:
-            response = make_response(jsonify( {"message": "extension not owned by user"}), 403)
-        return response
-
-    if request.method == 'GET':
-        exts = getUserExtensions(filterByUserId=current_user.id,searchFor=None,showPublicOnly=False)
-
-        return render_template('myextensions.html.j2', default_data=fetch_default_data_for_templates(), exts=exts)
+    return render_template('myextensions.html.j2', default_data=fetch_default_data_for_templates(), exts=exts)
 
 
 ## API V1
+
+@app.route('/api/v1/CreateUserExtension', methods=['POST'])
+@login_required
+def CreateUserExtension():
+    """
+    Create a user extension
+    ---
+    consumes:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          required:
+            - extension
+            - name
+            - info
+            - public
+          properties:
+            extension:
+              type: string
+            name:
+              type: string
+            info:
+              type: string
+            public:
+              type: boolean
+    responses:
+      200:
+        description: User extension successfully added
+    """
+    req_json = request.get_json()
+    ext = UserExtension()
+
+    ext.extension = html.escape(req_json['extension'])
+    ext.password = utilities.getRandomNumber(20)
+    ext.name = html.escape(req_json['name'])
+    ext.info = html.escape(req_json['info'])
+    ext.public = bool(req_json['public'])
+    ext.token = f'{token_prefix}{utilities.getRandomNumber(token_random_count)}'
+    ext.user_id = current_user.id
+
+    if len(ext.extension) == 4 and ext.extension.isdigit() and int(ext.extension[:1]) > 0:
+        try:
+            db.session.add(ext)
+            db.session.commit()
+
+            response = make_response(jsonify( {"message": "extension added"}), 200)
+
+            poke_asterisk_soon()
+        except:
+            response = make_response(jsonify( {"message": "extension can't be added. Do you need a voucher?"}), 400)
+
+    else:
+        response = make_response(jsonify( {"message": "you need 4 digits"}), 400)
+    return response
+
+@app.route('/api/v1/DeleteUserExtension', methods=['POST'])
+@login_required
+def DeleteUserExtension():
+    """
+    Delete a user extension
+    ---
+    consumes:
+      - application/json
+    parameters:
+      - in: body
+        name: body
+        required: true
+        schema:
+          type: object
+          required:
+            - extension
+          properties:
+            extension:
+              type: string
+    responses:
+      200:
+        description: User extension successfully deleted
+    """
+    req_json = request.get_json()
+    selection = db.select(UserExtension).filter_by(extension = req_json['extension'])
+    ext = db.session.execute(selection).first()
+
+    ext = ext[0]
+
+    if ext.user_id == current_user.id:
+        db.session.delete(ext)
+        db.session.commit()
+
+        response = make_response(jsonify( {"message": "extension deleted"}), 200)
+
+        poke_asterisk_soon()
+    else:
+        response = make_response(jsonify( {"message": "extension not owned by user"}), 403)
+    return response
+
+@app.route('/api/v1/GetUserExtensions', methods=['GET'])
+@login_required
+def GetUserExtensions():
+    """
+    Get all extensions of the current user
+    ---
+    responses:
+      200:
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: user name
+              extension:
+                type: string
+              token:
+                type: string
+              password:
+                type: string
+              info:
+                type: string
+    """
+    exts = [
+        {
+            "name": ext.name,
+            "extension": ext.extension,
+            "token": ext.token,
+            "password": ext.password,
+            "info": ext.info,
+        }
+        for ext in getUserExtensions(filterByUserId=current_user.id, searchFor=None, showPublicOnly=False)
+    ]
+    response = make_response(jsonify(exts), 200)
+    return response
 
 # TODO: change <token> to POST Parameter
 # TODO: fix 500 server error if no extensions is found

--- a/services/dect-wip/templates/myextensions.html.j2
+++ b/services/dect-wip/templates/myextensions.html.j2
@@ -131,8 +131,8 @@
             extension: extension,
         };
 
-        fetch(`${window.origin}/myextensions/`, {
-            method: "DELETE",
+        fetch(`${window.origin}/api/v1/DeleteUserExtension`, {
+            method: "POST",
             credentials: "include",
             body: JSON.stringify(entry),
             cache: "no-cache",
@@ -161,7 +161,7 @@
             public: public.checked
         };
 
-        fetch(`${window.origin}/myextensions/`, {
+        fetch(`${window.origin}/api/v1/CreateUserExtension`, {
             method: "POST",
             credentials: "include",
             body: JSON.stringify(entry),


### PR DESCRIPTION
- feat: move omm trigger to scheduler owned by ommsync
  Much neater to have the trigger where the action happens
  This also removes the requirement for the dect-wip to know the address and port of the ommsync service.
- feat: poke asterisk dynamically on change and every 5min to be sure
  To not spam the log of dect-wip and asterisk, the asterisk reloading is done more dynamically
- feat: move extension creation and deletion to API
  The `/myextensions` page actions are moved to the API