### PR TITLE
feat: moved html escape from pre database to post database

### DIFF
--- a/services/dect-wip/app.py
+++ b/services/dect-wip/app.py
@@ -229,10 +229,10 @@ def CreateUserExtension():
     req_json = request.get_json()
     ext = UserExtension()
 
-    ext.extension = html.escape(req_json['extension'])
+    ext.extension = req_json['extension']
     ext.password = utilities.getRandomNumber(20)
-    ext.name = html.escape(req_json['name'])
-    ext.info = html.escape(req_json['info'])
+    ext.name = req_json['name']
+    ext.info = req_json['info']
     ext.public = bool(req_json['public'])
     ext.token = f'{token_prefix}{utilities.getRandomNumber(token_random_count)}'
     ext.user_id = current_user.id

--- a/services/dect-wip/templates/myextensions.html.j2
+++ b/services/dect-wip/templates/myextensions.html.j2
@@ -47,13 +47,13 @@
 
         {% for ext in exts %}
             <tr>
-                <td>{{ext.name}}</td>
-                <td>{{ext.extension}}</td>
-                <td>{{ext.token | format_token}}</td>
-                <td>{{ext.password}}</td>
-                <td>{{ext.info}}</td>
+                <td>{{ ext.name | e }}</td>
+                <td>{{ ext.extension | e }}</td>
+                <td>{{ ext.token | e | format_token }}</td>
+                <td>{{ ext.password | e }}</td>
+                <td>{{ ext.info | e }}</td>
             <td>
-                    <button type="submit" class="btn btn-danger" onclick="delEntry('{{ext.extension}}')">
+                    <button type="submit" class="btn btn-danger" onclick="delEntry('{{ ext.extension | e }}')">
                         <i class="bi bi-trash"></i>
                     </button>
                 </td>

--- a/services/dect-wip/templates/phonebook.html.j2
+++ b/services/dect-wip/templates/phonebook.html.j2
@@ -33,9 +33,9 @@
 
             {% for ext in exts %}
                 <tr>
-                    <td>{{ext.extension}}</td>
-                    <td>{{ext.name}}</td>
-                    <td>{{ext.info}}</td>
+                    <td>{{ ext.extension | e }}</td>
+                    <td>{{ ext.name | e }}</td>
+                    <td>{{ ext.info | e }}</td>
                 </tr>
             {% endfor %}
 


### PR DESCRIPTION
Information that is in the database can be used in multiple different location: omm, html, javascript.
ATM we escape html that is escape in the OMM too but does not have to be escaped here.
It is better to save raw values in the database and do the proper escaping when the data is needed.